### PR TITLE
allow for update of treasury to prepare mainnet release

### DIFF
--- a/contracts/FluidityTap.sol
+++ b/contracts/FluidityTap.sol
@@ -56,9 +56,13 @@ contract FluidityTap is ERC20Detailed, ERC20Burnable, ERC20Mintable, Ownable, Wh
     /**
       * @notice Sets a new Treasury
       * @dev Can only be performed by owner.
-      *
       */
-    function updateTreasury(bytes9 _newCusip,  uint256 _newTotalFaceValue, uint256 _newMaturityDate) external onlyOwner {
+    function updateTreasury(
+        bytes9 _newCusip,
+        uint256 _newTotalFaceValue,
+        uint256 _newMaturityDate
+    )
+    external onlyOwner {
         cusip = _newCusip;
         totalFaceValue = _newTotalFaceValue;
         maturityDate = _newMaturityDate;

--- a/contracts/FluidityTap.sol
+++ b/contracts/FluidityTap.sol
@@ -54,6 +54,17 @@ contract FluidityTap is ERC20Detailed, ERC20Burnable, ERC20Mintable, Ownable, Wh
     }
 
     /**
+      * @notice Sets a new Treasury
+      * @dev Can only be performed by owner.
+      *
+      */
+    function updateTreasury(bytes9 _newCusip,  uint256 _newTotalFaceValue, uint256 _newMaturityDate) external onlyOwner {
+        cusip = _newCusip;
+        totalFaceValue = _newTotalFaceValue;
+        maturityDate = _newMaturityDate;
+    }
+
+    /**
      * @dev See `IERC20.transfer`.
      * @dev Can only transfer to whitelisted parties
      *

--- a/test/TestFluidityTap.js
+++ b/test/TestFluidityTap.js
@@ -12,6 +12,9 @@ contract('FluidityTap', async (accounts) => {
   const faceValue = 100000
   const cusip = '912794SL4'
   const JUL_3_12_00_00_UTC_2020 = 159377760015
+  const updatedfaceValue = 200000
+  const updateCusip = '501794GM1'
+  const AUG_12_12_00_00_UTC_2020 = 1597190400
   const custodianIdentifier = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef000000000000000000000000'
   const custodianAccount = 1111
   let fludityTapToken
@@ -225,5 +228,16 @@ contract('FluidityTap', async (accounts) => {
       await truffleAssert.passes(await txreceipt)
       assert.equal(adminBalance, (await fludityTapToken.balanceOf.call(nonAdmin)).toNumber())
     })
+  })
+
+  describe('Test updating the Treasury', async () => {
+    it('updating the treasury', async function () {
+      const txreceipt = await fludityTapToken.updateTreasury(web3.utils.fromAscii(updateCusip).slice(0, 20), updatedfaceValue, AUG_12_12_00_00_UTC_2020, {from: admin})
+      await truffleAssert.passes(await txreceipt)
+      assert.equal(updateCusip, web3.utils.toAscii(await fludityTapToken.cusip.call()), 'The cusip was not updated correctly')
+      assert.equal(updatedfaceValue, await fludityTapToken.totalFaceValue.call(), 'The total face value was not updated correctly')
+      assert.equal(AUG_12_12_00_00_UTC_2020, await fludityTapToken.maturityDate.call(), 'The maturity date was not updated correctly')
+  })
+
   })
 })

--- a/test/TestFluidityTap.js
+++ b/test/TestFluidityTap.js
@@ -232,12 +232,11 @@ contract('FluidityTap', async (accounts) => {
 
   describe('Test updating the Treasury', async () => {
     it('updating the treasury', async function () {
-      const txreceipt = await fludityTapToken.updateTreasury(web3.utils.fromAscii(updateCusip).slice(0, 20), updatedfaceValue, AUG_12_12_00_00_UTC_2020, {from: admin})
+      const txreceipt = await fludityTapToken.updateTreasury(web3.utils.fromAscii(updateCusip).slice(0, 20), updatedfaceValue, AUG_12_12_00_00_UTC_2020, { from: admin })
       await truffleAssert.passes(await txreceipt)
       assert.equal(updateCusip, web3.utils.toAscii(await fludityTapToken.cusip.call()), 'The cusip was not updated correctly')
       assert.equal(updatedfaceValue, await fludityTapToken.totalFaceValue.call(), 'The total face value was not updated correctly')
       assert.equal(AUG_12_12_00_00_UTC_2020, await fludityTapToken.maturityDate.call(), 'The maturity date was not updated correctly')
-  })
-
+    })
   })
 })


### PR DESCRIPTION
## Description

Ability to update treasury in case asset is not known or change through lifecycle of token
Change all parameters in a single function as we're updating all facets of the Treasury at once.

## Changes

New function called updateTreasury
Test case updated the and checking the results were updated.

